### PR TITLE
only highlight the current answer

### DIFF
--- a/pipelines.py
+++ b/pipelines.py
@@ -133,8 +133,8 @@ class QGPipeline:
         inputs = []
         for i, answer in enumerate(answers):
             if len(answer) == 0: continue
-            sent = sents[i]
             for answer_text in answer:
+                sent = sents[i]
                 sents_copy = sents[:]
                 
                 answer_text = answer_text.strip()


### PR DESCRIPTION
Fixes #42 .
This PR fixes the issue described in #42
If multiple answers were extracted from the same sentence then multiple answers were highlighted which resulted in some pure questions.