### PR TITLE
prediction_loss_only as an arg

### DIFF
--- a/run_qg.py
+++ b/run_qg.py
@@ -177,6 +177,9 @@ def main(args_file=None):
         mode="training",
         using_tpu=training_args.tpu_num_cores is not None
     )
+    
+    # Prediction Loss
+    training_args.prediction_loss_only=True,
 
     # Initialize our Trainer
     trainer = Trainer(
@@ -185,7 +188,6 @@ def main(args_file=None):
         train_dataset=train_dataset,
         eval_dataset=valid_dataset,
         data_collator=data_collator,
-        prediction_loss_only=True,
         label_smoothing=model_args.label_smoothing
     )
 


### PR DESCRIPTION
In the new version of the Trainer prediction_loss_only is not a part of the **kwargs, it should be passed as a separate arg.